### PR TITLE
Only show items for enable merchants

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -11,6 +11,6 @@ class WelcomeController < ApplicationController
   private
 
   def set_items
-    @items = Item.all
+    @items = Item.with_enabled_merchants
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,4 +16,9 @@ class Item < ApplicationRecord
     .max
     .date
   end
+
+  def self.with_enabled_merchants
+    joins(:merchant)
+      .where("merchants.status = ?", 1)
+  end
 end

--- a/spec/features/cart/add_item_spec.rb
+++ b/spec/features/cart/add_item_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "When a user adds items to their cart" do
   it "displays a message" do
     @user = create(:user, role: 1)
-    @merchant = create(:merchant, user: @user)
+    @merchant = create(:merchant, user: @user, status: 1)
     @item = create(:item, merchant: @merchant)
     @item2 = create(:item, merchant: @merchant)
 

--- a/spec/features/cart/remove_item_spec.rb
+++ b/spec/features/cart/remove_item_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "When a user adds items to their cart" do
   it "displays a message" do
     @user = create(:user, role: 1)
-    @merchant = create(:merchant, user: @user)
+    @merchant = create(:merchant, user: @user, status: 1)
     @item = create(:item, merchant: @merchant)
     @item2 = create(:item, merchant: @merchant)
 

--- a/spec/features/cart/show_spec.rb
+++ b/spec/features/cart/show_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe "When a user tries to checkout" do
   it "displays a message" do
     @user = create(:user, role: 1)
     @customer = create(:customer, user: @user)
-    @merchant = create(:merchant, user: @user)
+    @merchant = create(:merchant, user: @user, status: 1)
     @item = create(:item, merchant: @merchant)
     @item2 = create(:item, merchant: @merchant)
     @user1 = create(:user, role: 1)
     @customer1 = create(:customer, user: @user1)
-    @merchant1 = create(:merchant, user: @user1)
+    @merchant1 = create(:merchant, user: @user1, status: 1)
 
     visit "/"
 

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe "As a visitor" do
+	describe "when i visit the root path" do
+		it 'I can see all of the items with enabled merchants' do
+			@user1 = create(:user, role: 1)
+			@user2 = create(:user, role: 1)
+
+			@merchant_1 = create(:merchant, user: @user1, status: 1)
+			@merchant_2 = create(:merchant, user: @user2)
+
+			@item1 = create(:item, name: "A", merchant: @merchant_1)
+			@item2 = create(:item, name: "B", merchant: @merchant_1)
+			@item3 = create(:item, name: "C", merchant: @merchant_1)
+			@item4 = create(:item, name: "D", merchant: @merchant_1)
+
+			@item5 = create(:item, name: "A", merchant: @merchant_2)
+			@item6 = create(:item, name: "B", merchant: @merchant_2)
+			@item7 = create(:item, name: "C", merchant: @merchant_2)
+			@item8 = create(:item, name: "D", merchant: @merchant_2)
+
+			visit root_path
+
+			expect(page).to have_content(@item1.name)
+			expect(page).to have_content(@item2.name)
+			expect(page).to have_content(@item3.name)
+			expect(page).to have_content(@item4.name)
+		end
+	end
+end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,5 +1,0 @@
-require 'rails_helper'
-
-RSpec.describe Admin, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
-end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -45,4 +45,22 @@ RSpec.describe Item, type: :model do
       expect(@merchant_2.items.fourth.best_day).to eq(@invoice_33.date)
     end
   end
+
+  describe "Class methods" do
+    it '::with_enabled_merchants' do
+      @user1 = create(:user, role: 1)
+      @user2 = create(:user, role: 1)
+
+      @merchant_1 = create(:merchant, user: @user1, status: 1)
+      @merchant_2 = create(:merchant, user: @user2)
+
+      create_list(:item, 3, name: "xxx", merchant: @merchant_1)
+      create_list(:item, 6, merchant: @merchant_2)
+
+      expect(Item.with_enabled_merchants.count).to eq(3)
+      expect(Item.with_enabled_merchants.first.name).to eq("xxx")
+      expect(Item.with_enabled_merchants.second.name).to eq("xxx")
+      expect(Item.with_enabled_merchants.third.name).to eq("xxx")
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
Removes admin spec from previous version of user model (not needed)
Adds `with_enabled_merchants` w/ model and feature specs
Adds `enabled = 1` to fix test cases that `with_enabled_merchants` caused to fail
All tests passing



